### PR TITLE
Commited new override.css (removes youtube button)

### DIFF
--- a/lib/override.css
+++ b/lib/override.css
@@ -34,7 +34,7 @@ body[ready]:hover #mini-info, body[controls] #mini-info {
   overflow: hidden;
 }
 
-#material-player-right-wrapper, #material-player-left-wrapper .player-left .image-wrapper, #material-player-left-wrapper .now-playing-info-content, #material-player-left-wrapper [data-id="now-playing-menu"] {
+#material-player-right-wrapper, #material-player-left-wrapper .player-left .image-wrapper, #material-player-left-wrapper .now-playing-info-content, #player.material .now-playing-actions sj-icon-button, #player.material .now-playing-actions paper-icon-button{
   display: none;
 }
 


### PR DESCRIPTION
Okay here is the pull request. Again this is my first one so sorry if I screw it up. All I had to do was add some extra stuff to the display: none rule. Part of the extra css also removes another menu that appears when you have youtube red. 
